### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ options:
 
 | Option                | Description                                                       |
 | --------------------- | ----------------------------------------------------------------- |
-| `--url` (obligatoire) | URL de la vidéo Threads                                           |
-| `-to` / `--output`    | Dossier de sortie pour enregistrer la vidéo (défaut : `./`) |
+| `--url`               | URL de la vidéo Threads                                           |
+| `-to` / `--output`    | Dossier de sortie pour enregistrer la vidéo (défaut : `./`)       |
 | `-v` / `--version`    | Affiche la version de l’outil                                     |
 
 ### 2. Exemple


### PR DESCRIPTION
## Summary by Sourcery

Clean up the README options table by removing the obsolete ‘(obligatoire)’ label from the --url description and adjusting column alignment for consistency.

Documentation:
- Remove “(obligatoire)” label from --url option description in README
- Align table column spacing for the options section in README